### PR TITLE
Allow building with gcc 6.x

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -46,7 +46,7 @@ define fixup-kernel-cmd-file
 if [ -e $(1) ]; then cp $(1) $(1).bak; sed -e 's/\\\\\\\\/\\\\/g' < $(1).bak > $(1); rm -f $(1).bak; fi
 endef
 
-ifeq ($(notdir $(LOCAL_PATH)),$(strip $(LINUX_KERNEL_VERSION)))
+ifeq ($(notdir $(LOCAL_PATH)),$(strip $(notdir $(LINUX_KERNEL_VERSION))))
 ifneq ($(strip $(TARGET_NO_KERNEL)),true)
     KERNEL_DIR := $(LOCAL_PATH)
     BUILT_SYSTEMIMAGE := $(call intermediates-dir-for,PACKAGING,systemimage)/system.img

--- a/Makefile
+++ b/Makefile
@@ -768,6 +768,22 @@ KBUILD_CFLAGS   += $(call cc-option,-Werror=strict-prototypes)
 # Prohibit date/time macros, which would make the build non-deterministic
 KBUILD_CFLAGS   += $(call cc-option,-Werror=date-time)
 
+# Allow for warnings that didn't exist in gcc 4.x
+# Some of those are valid and should be fixed!
+KBUILD_CFLAGS   += $(call cc-option,-Wno-error=unused-const-variable)
+KBUILD_CFLAGS   += $(call cc-option,-Wno-error=misleading-indentation)
+KBUILD_CFLAGS   += $(call cc-option,-Wno-error=logical-not-parentheses)
+KBUILD_CFLAGS   += $(call cc-option,-Wno-error=discarded-array-qualifiers)
+KBUILD_CFLAGS   += $(call cc-option,-Wno-error=switch-bool)
+# And some warnings gcc 6.x catches in more cases
+# Should be fixed here:
+# drivers/misc/mediatek/aee/mrdump/mrdump_full.c:236:2: error: 'cpu' is used uninitialized in this function
+KBUILD_CFLAGS   += $(call cc-option,-Wno-error=uninitialized)
+# drivers/misc/mediatek/m4u/mt6797/m4u_hw.c:2104:36: error: array subscript is above array bounds [-Werror=array-bounds]
+KBUILD_CFLAGS   += $(call cc-option,-Wno-error=array-bounds)
+# drivers/misc/mediatek/video/mt6797/dispsys/ddp_ufoe.c:171:23: error: comparison of constant '3' with boolean expression is always false [-Werror=bool-compare]
+KBUILD_CFLAGS   += $(call cc-option,-Wno-error=bool-compare)
+
 # use the deterministic mode of AR if available
 KBUILD_ARFLAGS := $(call ar-option,D)
 

--- a/include/linux/compiler-gcc6.h
+++ b/include/linux/compiler-gcc6.h
@@ -1,0 +1,66 @@
+#ifndef __LINUX_COMPILER_H
+#error "Please don't include <linux/compiler-gcc6.h> directly, include <linux/compiler.h> instead."
+#endif
+
+#define __used				__attribute__((__used__))
+#define __must_check			__attribute__((warn_unused_result))
+#define __compiler_offsetof(a, b)	__builtin_offsetof(a, b)
+
+/* Mark functions as cold. gcc will assume any path leading to a call
+   to them will be unlikely.  This means a lot of manual unlikely()s
+   are unnecessary now for any paths leading to the usual suspects
+   like BUG(), printk(), panic() etc. [but let's keep them for now for
+   older compilers]
+
+   Early snapshots of gcc 4.3 don't support this and we can't detect this
+   in the preprocessor, but we can live with this because they're unreleased.
+   Maketime probing would be overkill here.
+
+   gcc also has a __attribute__((__hot__)) to move hot functions into
+   a special section, but I don't see any sense in this right now in
+   the kernel context */
+#define __cold			__attribute__((__cold__))
+
+#define __UNIQUE_ID(prefix) __PASTE(__PASTE(__UNIQUE_ID_, prefix), __COUNTER__)
+
+#ifndef __CHECKER__
+# define __compiletime_warning(message) __attribute__((warning(message)))
+# define __compiletime_error(message) __attribute__((error(message)))
+#endif /* __CHECKER__ */
+
+/*
+ * Mark a position in code as unreachable.  This can be used to
+ * suppress control flow warnings after asm blocks that transfer
+ * control elsewhere.
+ *
+ * Early snapshots of gcc 4.5 don't support this and we can't detect
+ * this in the preprocessor, but we can live with this because they're
+ * unreleased.  Really, we need to have autoconf for the kernel.
+ */
+#define unreachable() __builtin_unreachable()
+
+/* Mark a function definition as prohibited from being cloned. */
+#define __noclone	__attribute__((__noclone__))
+
+/*
+ * Tell the optimizer that something else uses this function or variable.
+ */
+#define __visible __attribute__((externally_visible))
+
+/*
+ * GCC 'asm goto' miscompiles certain code sequences:
+ *
+ *   http://gcc.gnu.org/bugzilla/show_bug.cgi?id=58670
+ *
+ * Work it around via a compiler barrier quirk suggested by Jakub Jelinek.
+ *
+ * (asm goto is automatically volatile - the naming reflects this.)
+ * This seems to be fixed in any 6.x compiler
+ */
+/* #define asm_volatile_goto(x...)	do { asm goto(x); asm (""); } while (0) */
+
+#ifdef CONFIG_ARCH_USE_BUILTIN_BSWAP
+#define __HAVE_BUILTIN_BSWAP32__
+#define __HAVE_BUILTIN_BSWAP64__
+#define __HAVE_BUILTIN_BSWAP16__
+#endif /* CONFIG_ARCH_USE_BUILTIN_BSWAP */


### PR DESCRIPTION
This fixes various compile failures with gcc 6.2.
It doesn't yet fix errors pointed out by new warnings
(instead making sure those warnings aren't turned into errors).

Signed-off-by: Bernhard Rosenkränzer <Bernhard.Rosenkranzer@linaro.org>