### PR TITLE
Allow building if the kernel isn't in the top level directory of AOSP sources

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -46,7 +46,7 @@ define fixup-kernel-cmd-file
 if [ -e $(1) ]; then cp $(1) $(1).bak; sed -e 's/\\\\\\\\/\\\\/g' < $(1).bak > $(1); rm -f $(1).bak; fi
 endef
 
-ifeq ($(notdir $(LOCAL_PATH)),$(strip $(LINUX_KERNEL_VERSION)))
+ifeq ($(notdir $(LOCAL_PATH)),$(strip $(notdir $(LINUX_KERNEL_VERSION))))
 ifneq ($(strip $(TARGET_NO_KERNEL)),true)
     KERNEL_DIR := $(LOCAL_PATH)
     BUILT_SYSTEMIMAGE := $(call intermediates-dir-for,PACKAGING,systemimage)/system.img


### PR DESCRIPTION
In the Linaro repositories, we check out multiple kernels (one for every
supported board that requires a non-mainline kernel), so we prefer
putting kernels into a subdirectory structure similar to the device/
directory structure.
This patch allows building in that structure without affecting builds
in the traditional location for x20 builds.

Signed-off-by: Bernhard Rosenkränzer <Bernhard.Rosenkranzer@linaro.org>