### PR TITLE
Remove unused parameter

### DIFF
--- a/drivers/misc/mediatek/aee/mrdump/mrdump_full.c
+++ b/drivers/misc/mediatek/aee/mrdump/mrdump_full.c
@@ -165,7 +165,7 @@ static void aee_kdump_cpu_stop(void *arg, void *regs, void *svc_sp)
 		cpu_relax();
 }
 
-static void __mrdump_reboot_stop_all(struct mrdump_crash_record *crash_record, int cpu)
+static void __mrdump_reboot_stop_all(struct mrdump_crash_record *crash_record)
 {
 	int timeout;
 
@@ -201,7 +201,7 @@ static void mrdump_stop_noncore_cpu(void *unused)
 		cpu_relax();
 }
 
-static void __mrdump_reboot_stop_all(struct mrdump_crash_record *crash_record, int cpu)
+static void __mrdump_reboot_stop_all(struct mrdump_crash_record *crash_record)
 {
 	unsigned long msecs;
 	atomic_set(&waiting_for_crash_ipi, num_online_cpus() - 1);
@@ -233,7 +233,7 @@ static void __mrdump_reboot_va(AEE_REBOOT_MODE reboot_mode, struct pt_regs *regs
 	local_fiq_disable();
 
 #if defined(CONFIG_SMP)
-	__mrdump_reboot_stop_all(crash_record, cpu);
+	__mrdump_reboot_stop_all(crash_record);
 #endif
 
 	cpu = get_HW_cpuid();


### PR DESCRIPTION
Don't require and pass the unused cpu parameter to __mrdump_reboot_stop_all

This also makes sure the cpu variable in __mrdump_reboot_va doesn't get
used before being initialized.

Signed-off-by: Bernhard Rosenkränzer <Bernhard.Rosenkranzer@linaro.org>