### PR TITLE
helio-x20 fix includes

### DIFF
--- a/drivers/cpufreq/Makefile
+++ b/drivers/cpufreq/Makefile
@@ -1,4 +1,5 @@
 
+ccflags-y += -I$(src)
 subdir-ccflags-y += -Werror
 
 # CPUfreq core

--- a/drivers/misc/mediatek/base/power/mt6797/Makefile
+++ b/drivers/misc/mediatek/base/power/mt6797/Makefile
@@ -11,6 +11,7 @@
 # GNU General Public License for more details.
 #
 
+ccflags-y += -I$(src)
 ccflags-y += -I$(srctree)/drivers/misc/mediatek/irq/$(MTK_PLATFORM)/
 ccflags-y += -I$(srctree)/drivers/misc/mediatek/dramc/$(MTK_PLATFORM)/
 ccflags-y += -I$(srctree)/drivers/misc/mediatek/base/power/include/

--- a/drivers/misc/mediatek/base/power/mt6797/mt_clkbuf_ctl.c
+++ b/drivers/misc/mediatek/base/power/mt6797/mt_clkbuf_ctl.c
@@ -42,7 +42,7 @@
 #include <mt_spm.h>
 #include <mach/mt_clkmgr.h>
 /* #include <mach/mt_gpio_core.h> */
-#include <mt_clkbuf_ctl.h>
+#include "mt_clkbuf_ctl.h"
 #include <mt-plat/upmu_common.h>
 
 #define RF_BPI_GPIO_NUM 20

--- a/drivers/misc/mediatek/base/power/ppm_v1/src/mach/mt6797/Makefile
+++ b/drivers/misc/mediatek/base/power/ppm_v1/src/mach/mt6797/Makefile
@@ -12,6 +12,7 @@
 #
 
 ccflags-y +=	\
+	-I$(src) \
 	-I$(PPM_ROOT_DIR)/inc \
 	-I$(srctree)/drivers/misc/mediatek/base/power/$(CONFIG_MTK_PLATFORM)/
 

--- a/drivers/misc/mediatek/cmdq/v2/mt6797/Makefile
+++ b/drivers/misc/mediatek/cmdq/v2/mt6797/Makefile
@@ -13,7 +13,8 @@
 
 # drivers/cmdq
 
-ccflags-y += -I$(srctree)/drivers/misc/mediatek/cmdq/v2 \
+ccflags-y += -I$(src) \
+	     -I$(srctree)/drivers/misc/mediatek/cmdq/v2 \
              -I$(srctree)/drivers/misc/mediatek/m4u/$(MTK_PLATFORM)
 
 # Enable MET

--- a/drivers/misc/mediatek/ext_disp/mt6797/Makefile
+++ b/drivers/misc/mediatek/ext_disp/mt6797/Makefile
@@ -15,7 +15,8 @@
 # Makefile for external display driver.
 #
 
-ccflags-y += -I$(srctree)/drivers/misc/mediatek/include/ \
+ccflags-y += -I$(src) \
+	     -I$(srctree)/drivers/misc/mediatek/include/ \
              -I$(srctree)/drivers/misc/mediatek/ext_disp/  \
              -I$(srctree)/drivers/misc/mediatek/ext_disp/common/test/ \
              -I$(srctree)/drivers/misc/mediatek/gpu/ged/include \

--- a/drivers/misc/mediatek/gpio/mt6797/6797_gpio.h
+++ b/drivers/misc/mediatek/gpio/mt6797/6797_gpio.h
@@ -13,7 +13,7 @@
 #ifndef _6797_GPIO_H
 #define _6797_GPIO_H
 
-#include <mt_gpio_base.h>
+#include "mt_gpio_base.h"
 #include <linux/slab.h>
 #include <linux/device.h>
 

--- a/drivers/misc/mediatek/gpio/mt6797/mt_gpio_affix.c
+++ b/drivers/misc/mediatek/gpio/mt6797/mt_gpio_affix.c
@@ -16,7 +16,7 @@
 #include <linux/types.h>
 #include <linux/device.h>
 #include <mt-plat/mt_gpio_core.h>
-#include <6797_gpio.h>
+#include "6797_gpio.h"
 
 
 void mt_gpio_pin_decrypt(unsigned long *cipher)

--- a/drivers/misc/mediatek/gpio/mt6797/mt_gpio_base.c
+++ b/drivers/misc/mediatek/gpio/mt6797/mt_gpio_base.c
@@ -9,13 +9,13 @@
  ******************************************************************************/
 
 
-#include <6797_gpio.h>
+#include "6797_gpio.h"
 #include <linux/types.h>
 #include "mt-plat/sync_write.h"
 #include <mt-plat/mt_gpio.h>
 #include <mt-plat/mt_gpio_core.h>
-#include <mt_gpio_base.h>
-#include <gpio_cfg.h>
+#include "mt_gpio_base.h"
+#include "gpio_cfg.h"
 #ifdef CONFIG_OF
 #include <linux/of_address.h>
 #endif

--- a/drivers/misc/mediatek/gpio/mt6797/mt_gpio_base_linux.c
+++ b/drivers/misc/mediatek/gpio/mt6797/mt_gpio_base_linux.c
@@ -18,7 +18,7 @@
 #include <linux/platform_device.h>
 #include <linux/seq_file.h>
 
-#include <mt_gpio_base.h>
+#include "mt_gpio_base.h"
 #include <mt-plat/mt_gpio_core.h>
 #include <linux/irqchip/mt-eic.h>
 #include <linux/interrupt.h>

--- a/drivers/misc/mediatek/gpio/mt6797/mt_gpio_debug.c
+++ b/drivers/misc/mediatek/gpio/mt6797/mt_gpio_debug.c
@@ -9,7 +9,7 @@
  ******************************************************************************/
 
 #include <linux/slab.h>
-#include <6797_gpio.h>
+#include "6797_gpio.h"
 #include <mt-plat/mt_gpio.h>
 #include <mt-plat/mt_gpio_core.h>
 

--- a/drivers/misc/mediatek/gpio/mt6797/mt_gpio_ext.c
+++ b/drivers/misc/mediatek/gpio/mt6797/mt_gpio_ext.c
@@ -10,7 +10,7 @@
 
 #include <mt-plat/mt_gpio.h>
 #include <mt-plat/mt_gpio_core.h>
-#include <mt_gpio_ext.h>
+#include "mt_gpio_ext.h"
 
 /* #define MAX_GPIO_REG_BITS      16 */
 /* #define MAX_GPIO_MODE_PER_REG  5 */

--- a/drivers/misc/mediatek/hdmi/mt8193/Makefile
+++ b/drivers/misc/mediatek/hdmi/mt8193/Makefile
@@ -13,6 +13,8 @@
 
 #include $(srctree)/drivers/misc/mediatek/Makefile.custom
 
+ccflags-y += -I$(src)
+
 ifeq ($(CONFIG_ARCH_MT6735M), y)
 ccflags-y += -I$(srctree)/drivers/misc/mediatek/ext_disp/mt6735m
 endif

--- a/drivers/misc/mediatek/m4u/mt6797/Makefile
+++ b/drivers/misc/mediatek/m4u/mt6797/Makefile
@@ -11,6 +11,7 @@
 # GNU General Public License for more details.
 #
 
+ccflags-y += -I$(src)
 ccflags-y += -I$(srctree)/drivers/staging/android/ion
 ccflags-y += -I$(srctree)/drivers/misc/mediatek/gud/$(MTK_PLATFORM)/gud/MobiCoreKernelApi/public
 ccflags-y += -I$(srctree)/drivers/misc/mediatek/gud/$(MTK_PLATFORM)/gud/MobiCoreKernelApi/include

--- a/drivers/misc/mediatek/mu3phy/Makefile
+++ b/drivers/misc/mediatek/mu3phy/Makefile
@@ -11,7 +11,8 @@
 # GNU General Public License for more details.
 #
 
-ccflags-y += -I$(srctree)/drivers/misc/mediatek/mu3d/drv \
+ccflags-y += -I$(src) \
+	     -I$(srctree)/drivers/misc/mediatek/mu3d/drv \
              -I$(srctree)/drivers/misc/mediatek/mu3d/hal \
              -I$(srctree)/drivers/misc/mediatek/mu3phy/$(CONFIG_MTK_PLATFORM)
 

--- a/drivers/misc/mediatek/power/mt6797/pmic.c
+++ b/drivers/misc/mediatek/power/mt6797/pmic.c
@@ -75,8 +75,8 @@
 #include <linux/gpio/consumer.h>
 #endif
 #include <mt-plat/upmu_common.h>
-#include <pmic.h>
-#include <pmic_irq.h>
+#include "pmic.h"
+#include "pmic_irq.h"
 /*#include <mach/eint.h> TBD*/
 #include <mach/mt_pmic_wrap.h>
 #if defined CONFIG_MTK_LEGACY
@@ -107,13 +107,13 @@
 #include <mach/mt_charging.h>
 
 #if defined(EXTERNAL_BUCK_FAN49101)
-#include <fan49101.h>
+#include "fan49101.h"
 #endif
 #if defined(EXTERNAL_BUCK_FAN53555)
-#include <fan53555.h>
+#include "fan53555.h"
 #endif
 #if defined(EXTERNAL_BUCK_DA9214)
-#include <da9214.h>
+#include "da9214.h"
 #endif
 
 /*****************************************************************************

--- a/drivers/misc/mediatek/power/mt6797/pmic_irq.c
+++ b/drivers/misc/mediatek/power/mt6797/pmic_irq.c
@@ -56,7 +56,7 @@
 #include <asm/uaccess.h>
 
 #include <mt-plat/upmu_common.h>
-#include <pmic.h>
+#include "pmic.h"
 /*#include <mach/eint.h> TBD*/
 #include <mach/mt_pmic_wrap.h>
 #include <mt-plat/mtk_rtc.h>
@@ -74,7 +74,7 @@
 #include <mt-plat/battery_common.h>
 #include <mach/mt_battery_meter.h>
 #endif
-#include <mt6311.h>
+#include "mt6311.h"
 #include <mach/mt_pmic.h>
 #include <mt-plat/mt_reboot.h>
 

--- a/drivers/misc/mediatek/uart/mt6797/Makefile
+++ b/drivers/misc/mediatek/uart/mt6797/Makefile
@@ -14,6 +14,7 @@
 #ccflags-y += -DCONFIG_MTK_FPGA
 #ccflags-y += -DFIX_TO_26M
 
+ccflags-y += -I$(src)
 ccflags-y += -I$(srctree)/drivers/misc/mediatek/uart
 ccflags-y += -I$(srctree)/drivers/misc/mediatek/base/power/$(CONFIG_MTK_PLATFORM)
 

--- a/drivers/misc/mediatek/video/mt6797/dispsys/Makefile
+++ b/drivers/misc/mediatek/video/mt6797/dispsys/Makefile
@@ -13,7 +13,8 @@
 
 # drivers/dispsys
 
-ccflags-y += -I$(srctree)/drivers/misc/mediatek/video/include/ \
+ccflags-y += -I$(src) \
+	     -I$(srctree)/drivers/misc/mediatek/video/include/ \
              -I$(srctree)/drivers/misc/mediatek/video/common/ \
              -I$(srctree)/drivers/misc/mediatek/video/common/rdma10/ \
              -I$(srctree)/drivers/misc/mediatek/video/common/wdma10/ \

--- a/drivers/misc/mediatek/video/mt6797/dispsys/ddp_pwm_mux.c
+++ b/drivers/misc/mediatek/video/mt6797/dispsys/ddp_pwm_mux.c
@@ -2,11 +2,11 @@
 #include <linux/clk.h>
 #include <linux/delay.h>
 #include <linux/sched.h>
-#include <ddp_clkmgr.h>
+#include "ddp_clkmgr.h"
 #include <ddp_pwm_mux.h>
 #include <linux/of.h>
 #include <linux/of_address.h>
-#include <ddp_reg.h>
+#include "ddp_reg.h"
 
 #define PWM_MSG(fmt, arg...) pr_debug("[PWM] " fmt "\n", ##arg)
 #define PWM_ERR(fmt, arg...) pr_err("[PWM] " fmt "\n", ##arg)

--- a/drivers/misc/mediatek/video/mt6797/videox/Makefile
+++ b/drivers/misc/mediatek/video/mt6797/videox/Makefile
@@ -38,7 +38,8 @@ obj-$(CONFIG_MTK_FB) += mtkfb_console.o		\
 #obj-y += mtkfb_dummy.o
 #endif
 
-ccflags-y += -I$(srctree)/drivers/misc/mediatek/video/include/     \
+ccflags-y += -I$(src) \
+	     -I$(srctree)/drivers/misc/mediatek/video/include/     \
              -I$(srctree)/drivers/misc/mediatek/video/common/   \
              -I$(srctree)/drivers/misc/mediatek/video/common/rdma10/ \
              -I$(srctree)/drivers/misc/mediatek/video/common/wdma10/ \

--- a/drivers/mmc/host/mediatek/mt6797/Makefile
+++ b/drivers/mmc/host/mediatek/mt6797/Makefile
@@ -11,6 +11,8 @@
 # GNU General Public License for more details.
 #
 
+ccflags-y += -I$(src)
+
 #add kernel source code path as head file search path
 MTK_PLATFORM := $(subst ",,$(CONFIG_MTK_PLATFORM))
 ccflags-y += -I$(srctree)/drivers/misc/mediatek/include

--- a/drivers/pinctrl/mediatek/pinctrl-mtk-mt6797.h
+++ b/drivers/pinctrl/mediatek/pinctrl-mtk-mt6797.h
@@ -8,7 +8,7 @@
 #define __PINCTRL_MTK_MT6797_H
 
 #include <linux/pinctrl/pinctrl.h>
-#include <pinctrl-mtk-common.h>
+#include "pinctrl-mtk-common.h"
 
 static const struct mtk_desc_pin mtk_pins_mt6797[] = {
 	MTK_PIN(

--- a/drivers/spi/mediatek/mt6797/mt_spi_hal.h
+++ b/drivers/spi/mediatek/mt6797/mt_spi_hal.h
@@ -17,7 +17,7 @@
 #include <linux/clk.h>
 #endif				/* !defined(CONFIG_MTK_CLKMGR) */
 #include <linux/wakelock.h>
-#include <mt_spi.h>
+#include "mt_spi.h"
 /*******************************************************************************
 * define macro for spi register
 ********************************************************************************/

--- a/drivers/spi/mediatek/mt6797/spi-dev.c
+++ b/drivers/spi/mediatek/mt6797/spi-dev.c
@@ -33,7 +33,7 @@
 #include <linux/dma-mapping.h>
 #include <linux/sched.h>
 #include "mt_spi_hal.h"
-#include <mt_spi.h>
+#include "mt_spi.h"
 #ifdef CONFIG_TRUSTONIC_TEE_SUPPORT
 #define SPI_TRUSTONIC_TEE_SUPPORT
 #endif

--- a/drivers/spi/mediatek/mt6797/spi.c
+++ b/drivers/spi/mediatek/mt6797/spi.c
@@ -39,7 +39,7 @@
 #include <linux/of_address.h>
 #endif
 /*#include <mach/irqs.h>*/
-#include <mt_spi.h>
+#include "mt_spi.h"
 #include "mt_spi_hal.h"
 /*#include <mach/mt_gpio.h>*/
 #include <mt-plat/mt_lpae.h>/* DMA */

--- a/drivers/usb/gadget/Makefile
+++ b/drivers/usb/gadget/Makefile
@@ -8,6 +8,7 @@ subdir-ccflags-y += -I$(srctree)/drivers/misc/mediatek/include
 subdir-ccflags-y += -I$(srctree)/drivers/misc/mediatek/include/mt-plat/$(MTK_PLATFORM)/include
 subdir-ccflags-y += -I$(srctree)/drivers/misc/mediatek/include/mt-plat
 
+ccflags-y += -I$(src)
 ccflags-y				+= -I$(srctree)/drivers/usb/gadget/udc -I$(srctree)/drivers/usb/gadget/function
 ccflags-y += -I$(srctree)/drivers/misc/mediatek/c2k_ccci/
 

--- a/drivers/usb/host/xhci-mtk.c
+++ b/drivers/usb/host/xhci-mtk.c
@@ -19,7 +19,7 @@
 #include <linux/list.h>
 #include <linux/platform_device.h>
 #include <linux/io.h>
-#include <xhci-mtk.h>
+#include "xhci-mtk.h"
 
 static struct sch_ep **ss_out_eps[MAX_EP_NUM];
 static struct sch_ep **ss_in_eps[MAX_EP_NUM];

--- a/drivers/usb/host/xhci-plat.c
+++ b/drivers/usb/host/xhci-plat.c
@@ -22,7 +22,7 @@
 #include "xhci.h"
 
 #ifdef CONFIG_USB_XHCI_MTK
-#include <xhci-mtk.h>
+#include "xhci-mtk.h"
 #endif
 
 #include "xhci-mvebu.h"

--- a/drivers/watchdog/mediatek/wdt/mt6797/mtk_wdt.c
+++ b/drivers/watchdog/mediatek/wdt/mt6797/mtk_wdt.c
@@ -24,7 +24,7 @@
 
 #include <asm/uaccess.h>
 #include <linux/types.h>
-#include <mt_wdt.h>
+#include "mt_wdt.h"
 #include <linux/delay.h>
 
 #include <linux/device.h>


### PR DESCRIPTION
Currently the x20 build relies on the original source directory being
added to the CLFAGS, however regular (non-android) kernel builds never
do this.

Rather than requiring a wrapper around the build system to force this
it is better to fix the Makefiles for drivers where this is required
(and to replace #include <> with #include "" for other drivers). This change
is mostly to benefit non-Android builds but should not cause regressions
for android.

Signed-off-by: Daniel Thompson <daniel.thompson@linaro.org>