### PR TITLE
helio-x20 fix make clean

### DIFF
--- a/drivers/misc/mediatek/Makefile
+++ b/drivers/misc/mediatek/Makefile
@@ -77,7 +77,6 @@ obj-$(CONFIG_MTK_I2C)  += i2c/
 endif
 obj-$(CONFIG_MTK_LEDS)	+= leds/
 obj-$(CONFIG_MTK_VIBRATOR)	+= vibrator/
-obj-$(CONFIG_MTK_SM100)	+= tc1_interface/vib_drv/
 obj-$(CONFIG_MTK_ACCDET)	+= accdet/
 obj-$(CONFIG_MTK_ECCCI_C2K) += c2k_usb/
 obj-y += irtx/


### PR DESCRIPTION
Currently drivers/misc/mediatek/Makefile refers to a non-existent
directory, this isn't enough to kill the default build because
CONFIG_MTK_SM100 is not set. However dead code like this *is* enough
to stop make clean from working properly.

Signed-off-by: Daniel Thompson <daniel.thompson@linaro.org>